### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "css": "atomizer -R -o projects/demo/src/styles.css --exclude \\*.css projects/demo/src"
   },
   "private": true,
+  "license": "MIT",
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.801.2",
     "@angular-devkit/build-ng-packagr": "~0.801.2",


### PR DESCRIPTION
Add missing license field to package.json file to help automated tools find how the software is licensed.