### PR TITLE
Update supported Angular version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NgxResizeObserver
 
-Angular 16.x library to monitor changes to elements. Uses ResizeObserver to do the work.
+Angular 17.x library to monitor changes to elements. Uses ResizeObserver to do the work.
 
 If you would like to simply know when elements are visible, check out [ngx-visibility](https://github.com/fidian/ngx-visibility/).
 


### PR DESCRIPTION
The readme stated Angular 16.x while in fact Angular 17 support has been added recently. Updated the documentation to reflect this important change.