### PR TITLE
Use afterNextRender hook to avoid observer initialization in SSR

### DIFF
--- a/projects/ngx-resize-observer/src/lib/ngx-resize-observer.directive.ts
+++ b/projects/ngx-resize-observer/src/lib/ngx-resize-observer.directive.ts
@@ -1,5 +1,5 @@
 import {
-    AfterViewInit,
+    afterNextRender,
     Directive,
     ElementRef,
     EventEmitter,
@@ -18,7 +18,7 @@ import {
     selector: '[onResize]'
 })
 export class NgxResizeObserverDirective
-    implements AfterViewInit, OnChanges, OnDestroy {
+    implements OnChanges, OnDestroy {
     @Input() resizeBoxModel = '';
     @Output() onResize = new EventEmitter<ResizeObserverEntry>();
     private observing = false;
@@ -26,10 +26,10 @@ export class NgxResizeObserverDirective
     constructor(
         private readonly elementRef: ElementRef,
         private readonly ngxResizeObserverService: NgxResizeObserverService
-    ) {}
-
-    ngAfterViewInit() {
-        this.observe();
+    ) {
+        afterNextRender(() => {
+            this.observe();
+        });
     }
 
     ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
When using SSR, the server tries to initialize the observer, which does not exist in the reduced version of server DOM API. Initialization on afterNextRender hook allows us to avoid server errors and init observer only in the browser context.